### PR TITLE
Improve localisation for radio options

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -6,8 +6,8 @@ module GOVUKDesignSystemFormBuilder
       def initialize(builder, object_name, attribute_name, text: nil, value: nil, size: nil, hidden: false, radio: false, checkbox: false, tag: nil, link_errors: true)
         super(builder, object_name, attribute_name)
 
-        @text           = label_text(text, hidden)
         @value          = value # used by field_id
+        @text           = label_text(text, hidden)
         @size_class     = label_size_class(size)
         @radio_class    = radio_class(radio)
         @checkbox_class = checkbox_class(checkbox)
@@ -39,7 +39,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def label_text(option_text, hidden)
-        text = [option_text, @value, localised_text(:label), @attribute_name.capitalize].compact.first.to_s
+        text = [option_text, localised_text(:label), @attribute_name.capitalize].compact.first.to_s
 
         if hidden
           tag.span(text, class: %w(govuk-visually-hidden))

--- a/lib/govuk_design_system_formbuilder/traits/localisation.rb
+++ b/lib/govuk_design_system_formbuilder/traits/localisation.rb
@@ -4,11 +4,9 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def localised_text(context)
-        key = localisation_key(context)
-
-        return nil unless I18n.exists?(key)
-
-        I18n.translate(key)
+        I18n.translate(
+          localisation_key(context), default: nil
+        )
       end
 
       def localisation_key(context)
@@ -19,8 +17,9 @@ module GOVUKDesignSystemFormBuilder
 
       def schema(context)
         schema_root(context)
-          .push(@object_name, @attribute_name)
+          .push(@object_name, @attribute_name, @value)
           .map { |e| e == :__context__ ? context : e }
+          .compact
           .join('.')
       end
 

--- a/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
@@ -25,6 +25,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
+    it_behaves_like 'a field that supports setting the label via localisation'
+
     context 'radio button hints' do
       subject do
         builder.govuk_radio_button(:favourite_colour, :red, hint_text: red_hint)

--- a/spec/support/locales/sample.en.yaml
+++ b/spec/support/locales/sample.en.yaml
@@ -3,7 +3,8 @@ helpers:
     person:
       name: Who goes there?
       cv: Tell us about your employment history
-      favourite_colour: What is your favourite colour?
+      favourite_colour:
+        red: Red
       photo: Upload a recent passport photo
   legend:
     person:

--- a/spec/support/shared/shared_localisation_examples.rb
+++ b/spec/support/shared/shared_localisation_examples.rb
@@ -6,7 +6,13 @@ shared_examples 'a field that supports setting the label via localisation' do
   let(:localisations) { LOCALISATIONS }
 
   context 'localising when no text is supplied' do
-    let(:expected_label) { I18n.translate("helpers.label.person.#{attribute}") }
+    let(:localisation_key) {
+      defined?(value) ? "#{attribute}.#{value}" : attribute
+    }
+    let(:expected_label) {
+      I18n.translate(localisation_key, scope: 'helpers.label.person')
+    }
+
     subject { builder.send(*args) }
 
     specify 'should set the label from the locales' do


### PR DESCRIPTION
Extend the localisation schema with the `value` of the radio option (for example "yes" or "no") to be able to localise these automatically.

Also avoid double lookups in method `localised_text`. No need to first check if a key exists, if we pass to the translate method a `nil` default. It will behave the same but make only one lookup.

This is a backwards compatible change so the interface to the `#govuk_collection_radio_buttons` method does not change, which means to be able to take the label from the locales, instead of providing to the method a `text_method`, just pass `nil`.

Example:

```ruby
f.govuk_collection_radio_buttons :parent, @values, :value, nil, inline: true
```

This makes for a bit ugly interface but could be improved later on. I didn't want to break compatibility.