### PR TITLE
Handle localisation for radios and check boxes

### DIFF
--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -1,4 +1,5 @@
 require 'active_support/configurable'
+require 'active_support/core_ext/string/inquiry'
 
 [%w(traits *.rb), %w(*.rb), %w(elements ** *.rb), %w(containers ** *.rb)]
   .flat_map { |matcher| Dir.glob(File.join(__dir__, 'govuk_design_system_formbuilder', *matcher)) }

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -55,11 +55,11 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def label_element
-          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, checkbox: true, value: @value, **@label, link_errors: @link_errors)
+          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, type: :checkbox, value: @value, **@label, link_errors: @link_errors)
         end
 
         def hint_element
-          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text, @value, checkbox: true)
+          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text, @value, type: :checkbox)
         end
 
         def conditional_classes

--- a/lib/govuk_design_system_formbuilder/elements/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/hint.rb
@@ -4,13 +4,12 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Hint
       include Traits::Localisation
 
-      def initialize(builder, object_name, attribute_name, text, value = nil, radio: false, checkbox: false)
+      def initialize(builder, object_name, attribute_name, text, value = nil, type: nil)
         super(builder, object_name, attribute_name)
 
         @value          = value
+        @type           = type.to_s.inquiry
         @hint_text      = hint_text(text)
-        @radio_class    = radio_class(radio)
-        @checkbox_class = checkbox_class(checkbox)
       end
 
       def html
@@ -29,15 +28,15 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def hint_classes
-        %w(govuk-hint).push(@radio_class, @checkbox_class).compact
+        %w(govuk-hint).push(radio_class, checkbox_class).compact
       end
 
-      def radio_class(radio)
-        radio ? 'govuk-radios__hint' : nil
+      def radio_class
+        'govuk-radios__hint' if @type.radio?
       end
 
-      def checkbox_class(checkbox)
-        checkbox ? 'govuk-checkboxes__hint' : nil
+      def checkbox_class
+        'govuk-checkboxes__hint' if @type.checkbox?
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -3,14 +3,13 @@ module GOVUKDesignSystemFormBuilder
     class Label < Base
       include Traits::Localisation
 
-      def initialize(builder, object_name, attribute_name, text: nil, value: nil, size: nil, hidden: false, radio: false, checkbox: false, tag: nil, link_errors: true)
+      def initialize(builder, object_name, attribute_name, text: nil, value: nil, size: nil, hidden: false, type: nil, tag: nil, link_errors: true)
         super(builder, object_name, attribute_name)
 
         @value          = value # used by field_id
+        @type           = type.to_s.inquiry
         @text           = label_text(text, hidden)
         @size_class     = label_size_class(size)
-        @radio_class    = radio_class(radio)
-        @checkbox_class = checkbox_class(checkbox)
         @tag            = tag
         @link_errors    = link_errors
       end
@@ -32,7 +31,7 @@ module GOVUKDesignSystemFormBuilder
           @attribute_name,
           value: @value,
           for: field_id(link_errors: @link_errors),
-          class: %w(govuk-label).push(@size_class, @weight_class, @radio_class, @checkbox_class).compact
+          class: %w(govuk-label).push(@size_class, @weight_class, radio_class, checkbox_class).compact
         ) do
           @text
         end
@@ -48,12 +47,12 @@ module GOVUKDesignSystemFormBuilder
         end
       end
 
-      def radio_class(radio)
-        radio ? 'govuk-radios__label' : nil
+      def radio_class
+        'govuk-radios__label' if @type.radio?
       end
 
-      def checkbox_class(checkbox)
-        checkbox ? 'govuk-checkboxes__label' : nil
+      def checkbox_class
+        'govuk-checkboxes__label' if @type.checkbox?
       end
 
       def label_size_class(size)

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
@@ -41,11 +41,11 @@ module GOVUKDesignSystemFormBuilder
       private
 
         def hint_element
-          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text, @value, radio: true)
+          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text, @value, type: :radio)
         end
 
         def label_element
-          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, text: @label_text, value: @value, radio: true, size: label_size, link_errors: @link_errors)
+          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, text: @label_text, value: @value, type: :radio, size: label_size, link_errors: @link_errors)
         end
 
         def label_size

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -39,11 +39,11 @@ module GOVUKDesignSystemFormBuilder
       private
 
         def label_element
-          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, radio: true, value: @value, **@label, link_errors: @link_errors)
+          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, type: :radio, value: @value, **@label, link_errors: @link_errors)
         end
 
         def hint_element
-          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text, @value, radio: true)
+          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text, @value, type: :radio)
         end
 
         def input

--- a/lib/govuk_design_system_formbuilder/traits/localisation.rb
+++ b/lib/govuk_design_system_formbuilder/traits/localisation.rb
@@ -17,10 +17,21 @@ module GOVUKDesignSystemFormBuilder
 
       def schema(context)
         schema_root(context)
-          .push(@object_name, @attribute_name, @value)
+          .push(*schema_path)
           .map { |e| e == :__context__ ? context : e }
-          .compact
           .join('.')
+      end
+
+      def schema_path
+        [].tap do |path|
+          path.push(@object_name)
+
+          if @value.present?
+            path.push("#{@attribute_name}_options", @value)
+          else
+            path.push(@attribute_name)
+          end
+        end
       end
 
       def schema_root(context)

--- a/spec/support/locales/sample.en.yaml
+++ b/spec/support/locales/sample.en.yaml
@@ -3,7 +3,8 @@ helpers:
     person:
       name: Who goes there?
       cv: Tell us about your employment history
-      favourite_colour:
+      favourite_colour: What is your favourite colour?
+      favourite_colour_options:
         red: Red
       photo: Upload a recent passport photo
   legend:

--- a/spec/support/shared/shared_localisation_examples.rb
+++ b/spec/support/shared/shared_localisation_examples.rb
@@ -7,7 +7,7 @@ shared_examples 'a field that supports setting the label via localisation' do
 
   context 'localising when no text is supplied' do
     let(:localisation_key) {
-      defined?(value) ? "#{attribute}.#{value}" : attribute
+      defined?(value) ? "#{attribute}_options.#{value}" : attribute
     }
     let(:expected_label) {
       I18n.translate(localisation_key, scope: 'helpers.label.person')


### PR DESCRIPTION
The previous PR was not handling the localisation properly in all scenarios.

This change should make it now possible to set separately labels and/or hints for either the fieldset or the individual radios/checkboxes inside that fieldset.

Also, a small refactor to simplify some methods signature.