### PR TITLE
Extend legend options to enable visually hidden

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -242,6 +242,7 @@ module GOVUKDesignSystemFormBuilder
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+, defaults to +h1+
+    # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
     # @example A collection of radio buttons for favourite colours, labels capitalised via a proc
@@ -290,6 +291,7 @@ module GOVUKDesignSystemFormBuilder
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
+    # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
     # @param block [Block] a block of HTML that will be used to populate the fieldset
     # @param classes [String] Classes to add to the radio button container.
     # @see https://design-system.service.gov.uk/components/radios/ GOV.UK Radios
@@ -315,6 +317,7 @@ module GOVUKDesignSystemFormBuilder
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
+    # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
     # @see https://design-system.service.gov.uk/components/radios/ GOV.UK Radios
     # @param block [Block] Any supplied HTML will be wrapped in a conditional
     #   container and only revealed when the radio button is picked
@@ -358,6 +361,7 @@ module GOVUKDesignSystemFormBuilder
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
+    # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
     # @param block [Block] any HTML passed in will be injected into the fieldset, after the hint and before the checkboxes
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
@@ -403,6 +407,7 @@ module GOVUKDesignSystemFormBuilder
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
+    # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
     # @param classes [String] Classes to add to the checkbox container.
     # @param block [Block] a block of HTML that will be used to populate the fieldset
     # @return [ActiveSupport::SafeBuffer] HTML output
@@ -503,6 +508,7 @@ module GOVUKDesignSystemFormBuilder
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
+    # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
     # @param omit_day [Boolean] do not render a day input, only capture month and year
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input group
     # @param date_of_birth [Boolean] if +true+ {https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Values birth date auto completion attributes}
@@ -545,6 +551,7 @@ module GOVUKDesignSystemFormBuilder
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
+    # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
     #
     # @example A fieldset containing address fields
     #   = f.govuk_fieldset legend: { text: 'Address' }

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -23,6 +23,7 @@ module GOVUKDesignSystemFormBuilder
 
       def legend_defaults
         {
+          hidden: false,
           text: nil,
           tag:  config.default_legend_tag,
           size: config.default_legend_size
@@ -49,7 +50,10 @@ module GOVUKDesignSystemFormBuilder
         size = @legend.dig(:size)
         fail "invalid size '#{size}', must be #{LEGEND_SIZES.join(', ')}" unless size.in?(LEGEND_SIZES)
 
-        ["govuk-fieldset__legend", "govuk-fieldset__legend--#{size}"]
+        classes = %W(govuk-fieldset__legend govuk-fieldset__legend--#{size})
+        classes.push('govuk-visually-hidden') if @legend.dig(:hidden)
+
+        classes
       end
 
       def legend_heading_classes

--- a/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
@@ -6,8 +6,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     let(:legend_text) { 'Current address' }
     let(:inner_text) { 'Where do you live?' }
 
+    let(:legend_options) { { text: legend_text } }
+
     subject do
-      builder.send(method, legend: { text: legend_text }) do
+      builder.send(method, legend: legend_options) do
         builder.tag.span(inner_text)
       end
     end
@@ -16,6 +18,18 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       expect(subject).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
         expect(fs).to have_tag('legend', text: legend_text)
         expect(fs).to have_tag('span', text: inner_text)
+      end
+    end
+
+    context 'when the fieldset legend is configured' do
+      let(:legend_options) { { text: legend_text, size: 'm', tag: 'h3', hidden: true } }
+
+      specify 'output should have classes according to size and visibility' do
+        expect(subject).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
+          expect(fs).to have_tag('legend', with: { class: 'govuk-fieldset__legend--m govuk-visually-hidden' }) do |lg|
+            expect(lg).to have_tag('h3', text: legend_text)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Allow to pass an optional option to the existing legend options hash, in a similar way to the one in labels, to add an extra class `govuk-visually-hidden` to the legend for those cases where we want to avoid visual repetition.

This is in line with recommendations from the design system:
https://design-system.service.gov.uk/get-started/labels-legends-headings/

However, this option only removes visual duplication and will not help users of screen readers. They will still hear both the page heading and the visually hidden `<label>` or `<legend>`.

To prevent this, set the contents of the `<label>` or `<legend>` as the page heading.